### PR TITLE
[feat] 会員登録機能の改善及びクリーンアップ機能の追加

### DIFF
--- a/src/main/java/com/hanyahunya/auth/AuthApplication.java
+++ b/src/main/java/com/hanyahunya/auth/AuthApplication.java
@@ -2,7 +2,9 @@ package com.hanyahunya.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class AuthApplication {
 

--- a/src/main/java/com/hanyahunya/auth/adapter/in/scheduler/UserCleanUpScheduler.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/scheduler/UserCleanUpScheduler.java
@@ -1,0 +1,17 @@
+package com.hanyahunya.auth.adapter.in.scheduler;
+
+import com.hanyahunya.auth.application.port.in.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserCleanUpScheduler {
+    private final AuthService authService;
+
+    @Scheduled(cron = "0 0 4 * * ?")
+    public void cleanupPendingUsers() {
+        authService.cleanupUnverifiedUsers();
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/SignupDto.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/SignupDto.java
@@ -1,11 +1,16 @@
 package com.hanyahunya.auth.adapter.in.web.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class SignupDto {
+    @Email
+    @NotBlank
     private String email;
+    @NotBlank
     private String password;
     private String locale;
 }

--- a/src/main/java/com/hanyahunya/auth/adapter/out/redis/RedisVerificationAdapter.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/out/redis/RedisVerificationAdapter.java
@@ -1,0 +1,41 @@
+package com.hanyahunya.auth.adapter.out.redis;
+
+import com.hanyahunya.auth.application.port.out.VerificationPort;
+import com.hanyahunya.auth.domain.util.RandomString;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisVerificationAdapter implements VerificationPort {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String VERIFICATION_KEY_PREFIX = "auth-service:signup:verify:";
+
+    @Override
+    public String createVerificationCode(UUID userId) {
+        String verificationCode = RandomString.generate(200);
+        redisTemplate.opsForValue().set(
+                VERIFICATION_KEY_PREFIX + verificationCode,
+                userId.toString(),
+                1, TimeUnit.HOURS
+        );
+        return verificationCode;
+    }
+
+    @Override
+    public Optional<String> getUserIdByVerificationCode(String verificationCode) {
+        String userId = redisTemplate.opsForValue().get(VERIFICATION_KEY_PREFIX + verificationCode);
+        return Optional.ofNullable(userId);
+    }
+
+    @Override
+    public void deleteVerificationCode(String verificationCode) {
+        redisTemplate.delete(VERIFICATION_KEY_PREFIX + verificationCode);
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/application/port/in/AuthService.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/in/AuthService.java
@@ -7,6 +7,10 @@ import com.hanyahunya.auth.application.dto.Tokens;
 public interface AuthService {
     void signUp(SignupDto signupDto);
     void completeSignup(String verificationCode);
+    void cleanupUnverifiedUsers();
 
     Tokens login(LoginDto loginDto);
+    
+    // todo: 소셜로그인 추가. provider, 고유 id 값이 없을경우 회원가입처리. 있을경우 연결된 User 객체 불러와서 처리
+    // todo: 소셜로그인용 회원가입 추가 (이메일, 비밀번호 없음 )
 }

--- a/src/main/java/com/hanyahunya/auth/application/port/out/VerificationPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/VerificationPort.java
@@ -1,0 +1,10 @@
+package com.hanyahunya.auth.application.port.out;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VerificationPort {
+    String createVerificationCode(UUID userId);
+    Optional<String> getUserIdByVerificationCode(String verificationCode);
+    void deleteVerificationCode(String verificationCode);
+}

--- a/src/main/java/com/hanyahunya/auth/domain/exception/InvalidVerificationCodeException.java
+++ b/src/main/java/com/hanyahunya/auth/domain/exception/InvalidVerificationCodeException.java
@@ -1,0 +1,10 @@
+package com.hanyahunya.auth.domain.exception;
+
+public class InvalidVerificationCodeException extends RuntimeException {
+    public InvalidVerificationCodeException() {
+      super("無効なメール認証コードです。");
+    }
+    public InvalidVerificationCodeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/domain/model/Role.java
+++ b/src/main/java/com/hanyahunya/auth/domain/model/Role.java
@@ -1,6 +1,6 @@
 package com.hanyahunya.auth.domain.model;
 
 public enum Role {
-    ADMIN,
-    USER
+    ROLE_ADMIN,
+    ROLE_USER
 }

--- a/src/main/java/com/hanyahunya/auth/domain/model/User.java
+++ b/src/main/java/com/hanyahunya/auth/domain/model/User.java
@@ -46,4 +46,8 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private Status status;
+
+    public void updateTimestamp() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/hanyahunya/auth/domain/repository/UserRepository.java
+++ b/src/main/java/com/hanyahunya/auth/domain/repository/UserRepository.java
@@ -1,17 +1,22 @@
 package com.hanyahunya.auth.domain.repository;
 
+import com.hanyahunya.auth.domain.model.Status;
 import com.hanyahunya.auth.domain.model.User; // 변경
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-    boolean existsByEmail(String email);
-
     @Modifying
     @Query(value = "UPDATE users u SET u.status = :status WHERE u.user_id = :userId AND u.status = 'PENDING_VERIFICATION'", nativeQuery = true)
     int updateUserStatus(@Param("userId") UUID userId, @Param("status") String status);
+
+    void deleteByStatusAndUpdatedAtBefore(Status status, LocalDateTime updatedAtBefore);
+
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
会員登録機能の全体的な構造改善と、未認証ユーザーの定期的なクリーンアップ機能を追加。

主な変更点:
- **Redis依存の分離**: Redis関連機能にもPort/Adapterパターンを導入し、認証サービスからRedis関連ロジックを`RedisVerificationAdapter`に分離。これによりテスト容易性と柔軟性が向上。（多分）
- **スケジューラの追加**: 会員登録後に放置された未認証ユーザーのため、毎日午前4時に動作し、認証が完了していないユーザーを自動的に削除するスケジューラを追加。