### PR TITLE
feat: トークン侵害検知時の処理を実装

### DIFF
--- a/src/main/java/com/hanyahunya/auth/adapter/in/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/handler/GlobalExceptionHandler.java
@@ -1,17 +1,23 @@
 package com.hanyahunya.auth.adapter.in.handler;
 
+import com.hanyahunya.auth.adapter.in.web.util.CookieUtil;
+import com.hanyahunya.auth.application.port.in.TokenCompromiseUseCase;
 import com.hanyahunya.auth.domain.exception.EmailAlreadyExistsException;
 import com.hanyahunya.auth.domain.exception.InvalidTokenException;
 import com.hanyahunya.auth.domain.exception.ResourceNotFoundException;
 import com.hanyahunya.auth.domain.exception.TokenCompromisedException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
     @ExceptionHandler(EmailAlreadyExistsException.class)
     public ResponseEntity<Void> handleEmailAlreadyExistsException(EmailAlreadyExistsException e) {
@@ -31,10 +37,20 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
+    private final TokenCompromiseUseCase tokenCompromiseUseCase;
+
     @ExceptionHandler(TokenCompromisedException.class)
     public ResponseEntity<Void> handleTokenCompromisedException(TokenCompromisedException e) {
-        log.warn("TokenCompromisedException: {}", e.getMessage());
-        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        log.warn("ユーザーID '{}' でトークンの侵害を検知しました。", e.getUserId());
+
+        tokenCompromiseUseCase.handleCompromise(e.getUserId());
+
+        ResponseCookie deletedCookie = CookieUtil.deleteRefreshTokenCookie();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.SET_COOKIE, deletedCookie.toString());
+
+        return new ResponseEntity<>(headers, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/hanyahunya/auth/adapter/out/grpc/MailServiceImpl.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/out/grpc/MailServiceImpl.java
@@ -1,6 +1,7 @@
 package com.hanyahunya.auth.adapter.out.grpc;
 
 import com.hanyahunya.auth.application.port.out.MailServicePort; // 변경
+import com.hanyahunya.auth.application.port.out.SecurityNotificationPort;
 import email_service.EmailRequest;
 import email_service.EmailResponse;
 import email_service.EmailServiceGrpc;
@@ -10,13 +11,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MailServiceImpl implements MailServicePort { // 변경
+public class MailServiceImpl implements MailServicePort, SecurityNotificationPort { // 변경
 
     private final EmailServiceGrpc.EmailServiceBlockingStub emailStub;
 
@@ -33,6 +37,17 @@ public class MailServiceImpl implements MailServicePort { // 변경
         String verificationLink = frontendUrl + "/verify/" + verificationCode;
         Map<String, String> variables = new HashMap<>();
         variables.put("verification_link", verificationLink);
+
+        sendMail(email, subjectKey, templateName, locale, variables);
+    }
+
+    @Override
+    public void sendCompromiseNotification(String email, LocalDateTime compromisedAt, String locale) {
+        String subjectKey = "email.test.title";
+        String templateName = "auth-test";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        Map<String, String> variables = new HashMap<>();
+        variables.put("compromise_time", compromisedAt.format(formatter));
 
         sendMail(email, subjectKey, templateName, locale, variables);
     }

--- a/src/main/java/com/hanyahunya/auth/application/port/in/TokenCompromiseUseCase.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/in/TokenCompromiseUseCase.java
@@ -1,0 +1,11 @@
+package com.hanyahunya.auth.application.port.in;
+
+import java.util.UUID;
+
+public interface TokenCompromiseUseCase {
+    /**
+     * 토큰탈취에 대한 후속 조치를 처리
+     * @param userId 탈취가 의심되는 userId
+     */
+    void handleCompromise(UUID userId);
+}

--- a/src/main/java/com/hanyahunya/auth/application/port/out/AccessLockPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/AccessLockPort.java
@@ -1,0 +1,9 @@
+package com.hanyahunya.auth.application.port.out;
+
+import java.util.UUID;
+
+public interface AccessLockPort {
+    void lock(UUID userId, long timeoutMinutes);
+
+    void unlock(UUID userId);
+}

--- a/src/main/java/com/hanyahunya/auth/application/port/out/SecurityNotificationPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/SecurityNotificationPort.java
@@ -1,0 +1,11 @@
+package com.hanyahunya.auth.application.port.out;
+
+import java.time.LocalDateTime;
+
+public interface SecurityNotificationPort {
+    /**
+     * 토큰 탈취 의심 알림 메일을 전송
+     * @param email 전송 대상 이메일
+     */
+    void sendCompromiseNotification(String email, LocalDateTime compromisedAt, String locale); // todo 추후 user 서비스에서 유저의 정보를 불러와 (닉네임, 국가등) 담아서 전송.
+}

--- a/src/main/java/com/hanyahunya/auth/application/service/TokenCompromiseService.java
+++ b/src/main/java/com/hanyahunya/auth/application/service/TokenCompromiseService.java
@@ -1,0 +1,42 @@
+package com.hanyahunya.auth.application.service;
+
+import com.hanyahunya.auth.application.port.in.TokenCompromiseUseCase;
+import com.hanyahunya.auth.application.port.out.AccessLockPort;
+import com.hanyahunya.auth.application.port.out.SecurityNotificationPort;
+import com.hanyahunya.auth.domain.model.Status;
+import com.hanyahunya.auth.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenCompromiseService implements TokenCompromiseUseCase {
+
+    private final AccessLockPort accessLockPort;
+    private final UserRepository userRepository;
+    private final SecurityNotificationPort securityNotificationPort;
+
+    @Override
+    @Transactional
+    public void handleCompromise(UUID userId) {
+        log.info("ユーザーID '{}' のトークン侵害を処理しています", userId);
+
+        accessLockPort.lock(userId, 15);
+
+        userRepository.findById(userId).ifPresent(user -> {
+            user.updateStatus(Status.COMPROMISED);
+//            userRepository.save(user); // Dirty Checking
+
+            // todo 추후 유저 닉네임, 로캘 정보 추가
+            securityNotificationPort.sendCompromiseNotification(user.getEmail(), LocalDateTime.now(), "ja-JP");
+
+            log.info("ユーザーID '{}' のトークン侵害処理が正常に完了しました。", userId);
+        });
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/domain/model/Status.java
+++ b/src/main/java/com/hanyahunya/auth/domain/model/Status.java
@@ -2,5 +2,6 @@ package com.hanyahunya.auth.domain.model;
 
 public enum Status {
     PENDING_VERIFICATION,
-    ACTIVE
+    ACTIVE,
+    COMPROMISED
 }

--- a/src/main/java/com/hanyahunya/auth/domain/model/User.java
+++ b/src/main/java/com/hanyahunya/auth/domain/model/User.java
@@ -50,4 +50,8 @@ public class User {
     public void updateTimestamp() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }


### PR DESCRIPTION
トークンが侵害された疑いがある場合のセキュリティを強化するため、関連処理を実装します。

TokenCompromisedException を例外ハンドラーで捕捉し、以下の処理を実行します。 -全トークン削除: 該当ユーザーのすべてのトークンを削除します。
-アクセスロック: すでに発行されたアクセストークンをブロックするため、Redisを利用して該当ユーザーのアクセスを15分間一時的にロックします。 -ステータス更新: ユーザーのDBステータスを COMPROMISED に変更します。
-通知メール送信: ユーザーにトークン侵害の疑いを知らせるセキュリティ警告メールを送信します
-クッキー削除: クライアント側に残っているリフレッシュトークンを無効化するため、クッキー削除のレスポンスヘッダーを返します。