### PR TITLE
feat: Kafkaによるユーザー登録イベントの発行機能を追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	// gRPC
 	implementation 'io.grpc:grpc-services'
 	implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'

--- a/src/main/java/com/hanyahunya/auth/adapter/out/kafka/UserEventKafkaAdapter.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/out/kafka/UserEventKafkaAdapter.java
@@ -1,0 +1,31 @@
+package com.hanyahunya.auth.adapter.out.kafka;
+
+import com.hanyahunya.auth.application.port.out.UserEventPublishPort;
+import com.hanyahunya.auth.domain.model.User;
+import com.hanyahunya.kafkaDto.UserSignedUpEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventKafkaAdapter implements UserEventPublishPort {
+
+    private final KafkaTemplate<String, UserSignedUpEvent> kafkaTemplate;
+    private static final String USER_EVENTS_TOPIC = "user-events";
+
+    @Override
+    public void publishUserSignedUpEvent(UserSignedUpEvent event) {
+        /*
+            가운데 매개변수 (user_id는 토픽의 어느 파티션에서 처리할지 정하는 역할.
+            -설정시-
+                > 같은 토픽에서 동일한 키가 있으면 파티션을 원래 키가 있던 파티션에 queue 형식으로 메시지를 넣음
+                -> 순서가 보장됨. ex) 회원가입 -> 회원정보 변경이 같은 토픽, 같은 키면 회원가입 후에 정보변경이 보장됨.
+            -미설정시-
+                > 위와 동일한 상황에서 같은 토픽이여도 파티션이 나뉘기에 A파티션에 회원가입 이벤트가있고, B파티션에 정보변경 이벤트가 있을때 B가 처리속도가 빨라서 B가 먼저 실행되버릴수 있음 -> 오류
+                > 토픽이 다르면 딱히 키는 상관없지만 너무 잘게 이벤트별로 나누는거보단 도메인별로 나누는게 좋아보임.
+                -> 그럼 처리는 어떻게 하냐? 같은 user-events topic으로 발행. Consumer에서 @KafkaListener(topics = "user-events" ...) @KafkaHandler로 라우팅 방식으로 처리!
+         */
+        kafkaTemplate.send(USER_EVENTS_TOPIC, event.getUserId().toString(), event);
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/application/port/out/UserEventPublishPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/UserEventPublishPort.java
@@ -1,0 +1,7 @@
+package com.hanyahunya.auth.application.port.out;
+
+import com.hanyahunya.kafkaDto.UserSignedUpEvent;
+
+public interface UserEventPublishPort {
+    void publishUserSignedUpEvent(UserSignedUpEvent event);
+}

--- a/src/main/java/com/hanyahunya/kafkaDto/UserSignedUpEvent.java
+++ b/src/main/java/com/hanyahunya/kafkaDto/UserSignedUpEvent.java
@@ -1,0 +1,20 @@
+package com.hanyahunya.kafkaDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignedUpEvent {
+    private UUID userId;
+    private String email;
+    private String country;
+    private LocalDateTime signedUpAt;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,41 +1,41 @@
-spring.application.name=auth
-server.port=8081
-
-app.frontend.url=https://hanyahunya.com/taske
-
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
-
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=${TASKE_DB_URL}
-spring.datasource.username=${TASKE_DB_USERNAME}
-spring.datasource.password=${TASKE_DB_PASSWORD}
-
-spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.generate-ddl=true
-spring.jpa.show-sql=false
-
-### need change ###
-spring.data.redis.host=${TASKE_REDIS_HOST}
-spring.data.redis.port=${TASKE_REDIS_PORT}
-spring.data.redis.password=${TASKE_REDIS_PW}
-
-# jwt
-jwt.accesstoken.secret=${TASKE_JWT_ACCESS_SECRET}
-jwt.refreshtoken.secret=${TASKE_JWT_REFRESH_SECRET}
-
-# encoder
-encoder.secret=${TASKE_ENCODER_SECRET}
-
-# gRPC
-spring.grpc.client.worker-service.address=static://localhost:9090
-spring.grpc.client.worker-service.negotiation-type=plaintext
-
-
-spring.mail.host=${TASKE_SMTP_HOST}
-spring.mail.port=${TASKE_SMTP_PORT}
-spring.mail.username=${TASKE_SMTP_USER}
-spring.mail.password=${TASKE_SMTP_PW}
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.ssl.trust=${TASKE_SMTP_HOST}
+#spring.application.name=auth
+#server.port=8081
+#
+#app.frontend.url=https://hanyahunya.com/taske
+#
+#spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+#
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.url=${TASKE_DB_URL}
+#spring.datasource.username=${TASKE_DB_USERNAME}
+#spring.datasource.password=${TASKE_DB_PASSWORD}
+#
+#spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+#spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.generate-ddl=true
+#spring.jpa.show-sql=false
+#
+#### need change ###
+#spring.data.redis.host=${TASKE_REDIS_HOST}
+#spring.data.redis.port=${TASKE_REDIS_PORT}
+#spring.data.redis.password=${TASKE_REDIS_PW}
+#
+## jwt
+#jwt.accesstoken.secret=${TASKE_JWT_ACCESS_SECRET}
+#jwt.refreshtoken.secret=${TASKE_JWT_REFRESH_SECRET}
+#
+## encoder
+#encoder.secret=${TASKE_ENCODER_SECRET}
+#
+## gRPC
+#spring.grpc.client.worker-service.address=static://localhost:9090
+#spring.grpc.client.worker-service.negotiation-type=plaintext
+#
+#
+#spring.mail.host=${TASKE_SMTP_HOST}
+#spring.mail.port=${TASKE_SMTP_PORT}
+#spring.mail.username=${TASKE_SMTP_USER}
+#spring.mail.password=${TASKE_SMTP_PW}
+#spring.mail.properties.mail.smtp.auth=true
+#spring.mail.properties.mail.smtp.starttls.enable=true
+#spring.mail.properties.mail.smtp.ssl.trust=${TASKE_SMTP_HOST}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,78 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: auth
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${TASKE_DB_URL}
+    username: ${TASKE_DB_USERNAME}
+    password: ${TASKE_DB_PASSWORD}
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    generate-ddl: true
+    show-sql: false
+  # need change
+  data:
+    redis:
+      host: ${TASKE_REDIS_HOST}
+      port: ${TASKE_REDIS_PORT}
+      password: ${TASKE_REDIS_PW}
+  # kafka
+  kafka:
+    bootstrap-servers: localhost:29092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+    consumer:
+      group-id: auth-group
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      auto-offset-reset: earliest
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "com.hanyahunya.kafkaDto.*"
+        spring.json.use.type.headers: true
+  # gRPC
+  grpc:
+    client:
+      worker-service:
+        address: static://localhost:9090
+        negotiation-type: plaintext
+  # mail
+  mail:
+    host: ${TASKE_SMTP_HOST}
+    port: ${TASKE_SMTP_PORT}
+    username: ${TASKE_SMTP_USER}
+    password: ${TASKE_SMTP_PW}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          ssl:
+            trust: ${TASKE_SMTP_HOST}
+
+app:
+  frontend:
+    url: https://hanyahunya.com/taske
+
+# jwt
+jwt:
+  accesstoken:
+    secret: ${TASKE_JWT_ACCESS_SECRET}
+  refreshtoken:
+    secret: ${TASKE_JWT_REFRESH_SECRET}
+
+# encoder
+encoder:
+  secret: ${TASKE_ENCODER_SECRET}


### PR DESCRIPTION
設定ファイルの管理方式を `application.properties` から `application.yml` へ移行。

ユーザー登録プロセス完了時に、後続処理のためにKafkaへ `UserSignedUpEvent` を発行するよう追加しました。

- `UserEventPublishPort` と `UserEventKafkaAdapter` を追加。

- イベントデータを格納する `UserSignedUpEvent` DTOを kafkaDto パッケージに定義。

- `AuthServiceImpl` でユーザー保存後、イベント発行ポートを呼び出す処理を追加。