### PR TITLE
feat: 正常系ログインロジック実装とアーキテクチャ改善

### DIFF
--- a/src/main/java/com/hanyahunya/auth/adapter/in/web/AuthController.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/web/AuthController.java
@@ -1,10 +1,16 @@
 package com.hanyahunya.auth.adapter.in.web;
 
 import com.hanyahunya.auth.adapter.in.web.dto.LoginDto;
-import com.hanyahunya.auth.application.port.in.AuthService;
 import com.hanyahunya.auth.adapter.in.web.dto.SignupDto;
+import com.hanyahunya.auth.adapter.in.web.util.CookieUtil;
+import com.hanyahunya.auth.application.command.LoginCommand;
+import com.hanyahunya.auth.application.command.SignupCommand;
+import com.hanyahunya.auth.application.dto.Tokens;
+import com.hanyahunya.auth.application.port.in.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,7 +21,10 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signup(@RequestBody @Valid SignupDto signupDto) {
-        authService.signUp(signupDto);
+
+        SignupCommand signupCommand = new SignupCommand(signupDto.getEmail(), signupDto.getPassword(), signupDto.getLocale());
+
+        authService.signUp(signupCommand);
         return ResponseEntity.ok().build();
     }
 
@@ -25,8 +34,21 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    // todo 로그인시 ACTIVE 가 아니면, 202 (요청은 수신했으나 처리가 완료되지 않음) 를 반환후 프론트에선 인증번호 입력 화면 보여주기. *redis에 5분간 유효한 데이터 저장. userId 같은거 + 지금 로그인한 기기에서만 작동하게
+    // todo -> 이미 로그인 한 상태 id, pw 입력후 화면. 202 리턴시 적절한 값 (랜덤 String 같은거) 전달후 /login/verify 에서 해당 값도 받게하면 좋을듯
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody @Valid LoginDto loginDto) {
+    public ResponseEntity<Void> login(@RequestBody @Valid LoginDto loginDto) {
+
+        LoginCommand command = new LoginCommand(loginDto.getEmail(), loginDto.getPassword());
+
+        Tokens tokens = authService.login(command);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + tokens.getAccessToken());
+        ResponseCookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(tokens.getRefreshToken());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ResponseEntity.ok().headers(headers).build();
 
     }
 }

--- a/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/LoginDto.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/LoginDto.java
@@ -1,4 +1,15 @@
 package com.hanyahunya.auth.adapter.in.web.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
 public class LoginDto {
+    @Email
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String password;
 }

--- a/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/SignupDto.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/SignupDto.java
@@ -1,16 +1,18 @@
 package com.hanyahunya.auth.adapter.in.web.dto;
 
+import com.hanyahunya.auth.global.validation.SupportedLocale;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import lombok.Setter;
 
-@Getter @Setter
+@Getter
 public class SignupDto {
     @Email
     @NotBlank
     private String email;
     @NotBlank
     private String password;
+    @NotBlank
+    @SupportedLocale
     private String locale;
 }

--- a/src/main/java/com/hanyahunya/auth/adapter/out/kafka/UserEventKafkaAdapter.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/out/kafka/UserEventKafkaAdapter.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class UserEventKafkaAdapter implements UserEventPublishPort {
 
     private final KafkaTemplate<String, UserSignedUpEvent> kafkaTemplate;
-    private static final String USER_EVENTS_TOPIC = "user-events";
+    private static final String USER_EVENT_TOPIC = "user-events";
 
     @Override
     public void publishUserSignedUpEvent(UserSignedUpEvent event) {
@@ -26,6 +26,6 @@ public class UserEventKafkaAdapter implements UserEventPublishPort {
                 > 토픽이 다르면 딱히 키는 상관없지만 너무 잘게 이벤트별로 나누는거보단 도메인별로 나누는게 좋아보임.
                 -> 그럼 처리는 어떻게 하냐? 같은 user-events topic으로 발행. Consumer에서 @KafkaListener(topics = "user-events" ...) @KafkaHandler로 라우팅 방식으로 처리!
          */
-        kafkaTemplate.send(USER_EVENTS_TOPIC, event.getUserId().toString(), event);
+        kafkaTemplate.send(USER_EVENT_TOPIC, event.getUserId().toString(), event);
     }
 }

--- a/src/main/java/com/hanyahunya/auth/application/command/LoginCommand.java
+++ b/src/main/java/com/hanyahunya/auth/application/command/LoginCommand.java
@@ -1,0 +1,4 @@
+package com.hanyahunya.auth.application.command;
+
+public record LoginCommand(String email, String password) {
+}

--- a/src/main/java/com/hanyahunya/auth/application/command/SignupCommand.java
+++ b/src/main/java/com/hanyahunya/auth/application/command/SignupCommand.java
@@ -1,0 +1,7 @@
+package com.hanyahunya.auth.application.command;
+
+public record SignupCommand (
+        String email,
+        String password,
+        String locale
+) {}

--- a/src/main/java/com/hanyahunya/auth/application/port/out/MailServicePort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/MailServicePort.java
@@ -2,4 +2,6 @@ package com.hanyahunya.auth.application.port.out;
 
 public interface MailServicePort {
     void sendVerificationEmail(String email, String verificationCode, String locale);
+
+    void sendVerificationCode(String email, String verificationCode);
 }

--- a/src/main/java/com/hanyahunya/auth/application/port/out/VerificationPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/VerificationPort.java
@@ -1,13 +1,13 @@
 package com.hanyahunya.auth.application.port.out;
 
-import com.hanyahunya.auth.adapter.in.web.dto.SignupDto;
+import com.hanyahunya.auth.application.command.SignupCommand;
 
 import java.util.Optional;
 
 public interface VerificationPort {
-    String createTemporaryUser(SignupDto signupDto);
+    String createTemporaryUser(String email, String password, String locale);
 
-    Optional<SignupDto> findTemporaryUserByCode(String verificationCode);
+    Optional<SignupCommand> findTemporaryUserByCode(String verificationCode);
 
     boolean isCooldown(String email);
 

--- a/src/main/java/com/hanyahunya/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/hanyahunya/auth/application/service/AuthServiceImpl.java
@@ -1,14 +1,12 @@
 package com.hanyahunya.auth.application.service;
 
 import com.hanyahunya.auth.adapter.in.web.dto.LoginDto;
+import com.hanyahunya.auth.application.command.LoginCommand;
 import com.hanyahunya.auth.application.dto.Tokens;
 import com.hanyahunya.auth.application.port.in.AuthService;
 import com.hanyahunya.auth.application.port.in.TokenService;
-import com.hanyahunya.auth.application.port.out.EncodeServicePort;
-import com.hanyahunya.auth.application.port.out.MailServicePort;
-import com.hanyahunya.auth.adapter.in.web.dto.SignupDto;
-import com.hanyahunya.auth.application.port.out.UserEventPublishPort;
-import com.hanyahunya.auth.application.port.out.VerificationPort;
+import com.hanyahunya.auth.application.port.out.*;
+import com.hanyahunya.auth.application.command.SignupCommand;
 import com.hanyahunya.auth.domain.exception.*;
 import com.hanyahunya.auth.domain.model.Role;
 import com.hanyahunya.auth.domain.model.Status;
@@ -30,42 +28,47 @@ public class AuthServiceImpl implements AuthService {
     private final VerificationPort verificationPort;
     private final MailServicePort mailService;
     private final UserEventPublishPort userEventPublishPort;
+    private final TokenService tokenService;
 
     @Transactional
     @Override
-    public void signUp(SignupDto signupDto) {
-        userRepository.findByEmail(signupDto.getEmail())
+    public void signUp(SignupCommand command) {
+        String email = command.email();
+        String encodedPassword = encodeService.encode(command.password());
+        String locale = command.locale();
+
+        userRepository.findByEmail(email)
                 .ifPresent(user -> {
                     throw new EmailAlreadyExistsException();
                 });
-        if (verificationPort.isCooldown(signupDto.getEmail())) {
+        if (verificationPort.isCooldown(email)) {
             throw new VerificationCooldownException("認証メールはすでに送信されています。受信したメールをご確認ください。");
         }
-        signupDto.setPassword(encodeService.encode(signupDto.getPassword()));
-        String verificationCode = verificationPort.createTemporaryUser(signupDto);
-        mailService.sendVerificationEmail(signupDto.getEmail(), verificationCode, signupDto.getLocale());
+        String verificationCode = verificationPort.createTemporaryUser(email, encodedPassword, locale);
+        mailService.sendVerificationEmail(email, verificationCode, locale);
     }
 
     @Transactional
     @Override
     public void completeSignup(String verificationCode) {
-        SignupDto dto = verificationPort.findTemporaryUserByCode(verificationCode)
+        SignupCommand command = verificationPort.findTemporaryUserByCode(verificationCode)
                 .orElseThrow(InvalidVerificationCodeException::new);
 
         UUID userId = UUID.randomUUID();
         User user = User.builder()
                 .userId(userId)
-                .email(dto.getEmail())
-                .password(dto.getPassword())
+                .email(command.email())
+                .password(command.password())
+                // 회원가입시에만 이렇게 저장하고, 정보 변경시에는 kafka 이벤트로 처리
+                .country(command.locale())
                 .role(Role.ROLE_USER)
                 .status(Status.ACTIVE)
                 .build();
         userRepository.save(user);
-        // todo Kafka 유저 가입 이벤트 발급
         UserSignedUpEvent userSignedUpEvent = UserSignedUpEvent.builder()
                 .userId(userId)
-                .email(dto.getEmail())
-                .country(dto.getLocale())
+                .email(command.email())
+                .country(command.locale())
                 .signedUpAt(LocalDateTime.now())
                 .build();
         userEventPublishPort.publishUserSignedUpEvent(userSignedUpEvent);
@@ -73,7 +76,22 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public Tokens login(LoginDto loginDto) {
-        return null;
+    public Tokens login(LoginCommand command) {
+        User user = userRepository.findByEmail(command.email())
+                .orElseThrow(LoginFailedException::new);
+        if (!encodeService.matches(command.password(), user.getPassword())) {
+            throw new LoginFailedException();
+        }
+        return switch (user.getStatus()) {
+            case ACTIVE -> tokenService.loginAndIssueTokens(user);
+            // todo 임시 토큰 발급(새로 + purpose) 3분 claims-email, redis에 key: ~~~:2fa:~~~@~~.com value:6int, 인증후에 해당 유저 로그인처리.
+            case COMPROMISED -> {
+                throw new RuntimeException("<UNK>");
+            }
+            // todo 이메일 인증후에 로그인 해달라고 요청.(이건 프론트 엔드에서)
+            case PENDING_VERIFICATION -> {
+                throw new RuntimeException("<UdNK>");
+            }
+        };
     }
 }

--- a/src/main/java/com/hanyahunya/auth/application/service/TokenCompromiseService.java
+++ b/src/main/java/com/hanyahunya/auth/application/service/TokenCompromiseService.java
@@ -43,8 +43,7 @@ public class TokenCompromiseService implements TokenCompromiseUseCase {
                     .atZone(ZoneId.systemDefault())
                     .toLocalDateTime();
 
-            // todo 추후 유저 닉네임, 로캘 정보 추가
-            securityNotificationPort.sendCompromiseNotification(user.getEmail(), localDateTime, "ja-JP");
+            securityNotificationPort.sendCompromiseNotification(user.getEmail(), localDateTime, user.getCountry());
 
             log.info("ユーザーID '{}' のトークン侵害処理が正常に完了しました。", userId);
         });

--- a/src/main/java/com/hanyahunya/auth/domain/exception/LoginFailedException.java
+++ b/src/main/java/com/hanyahunya/auth/domain/exception/LoginFailedException.java
@@ -1,0 +1,7 @@
+package com.hanyahunya.auth.domain.exception;
+
+public class LoginFailedException extends RuntimeException {
+    public LoginFailedException() {
+        super("Failed to login");
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/domain/model/User.java
+++ b/src/main/java/com/hanyahunya/auth/domain/model/User.java
@@ -47,6 +47,9 @@ public class User {
     @Column(name = "status")
     private Status status;
 
+    @Column(name = "country", length = 32)
+    private String country;
+
     public void updateTimestamp() {
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/hanyahunya/auth/global/validation/SupportedLocale.java
+++ b/src/main/java/com/hanyahunya/auth/global/validation/SupportedLocale.java
@@ -1,0 +1,24 @@
+package com.hanyahunya.auth.global.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD}) // 이 어노테이션을 어디에 붙일수 있는지 지정.
+@Retention(RUNTIME) // 이 어노테이션이 언제까지 유지될지.
+@Constraint(validatedBy = SupportedLocaleValidator.class) // 이 어노테이션의 유효성 검사를 어떤 클래스가 담당하는지
+public @interface SupportedLocale {
+    // 유효성 검사 실패 시 보여줄 기본 메시지
+    String message() default "Unsupported locale.";
+
+    //-------이 밑에는 나중에 어노테이션 더 알고싶을때 공부. 일단은 기본값--------
+    // 유효성 검사 그룹을 지정 (기본값: 비어있음)
+    Class<?>[] groups() default {};
+
+    // 유효성 검사에 대한 심각도 등을 표현 (기본값: 비어있음)
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/hanyahunya/auth/global/validation/SupportedLocaleValidator.java
+++ b/src/main/java/com/hanyahunya/auth/global/validation/SupportedLocaleValidator.java
@@ -1,0 +1,19 @@
+package com.hanyahunya.auth.global.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class SupportedLocaleValidator implements ConstraintValidator<SupportedLocale, String> {
+
+    private static final Set<String> SUPPORT_LOCALES = Set.of("ja-JP", "ko-KR", "en-US");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // 값이 없을경우엔 우리가 처리안하고 다른 어노테이션한테 위임하겠다. @NotNull 같은거
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+        return SUPPORT_LOCALES.contains(value);
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/infra/filter/UserContextFilter.java
+++ b/src/main/java/com/hanyahunya/auth/infra/filter/UserContextFilter.java
@@ -1,0 +1,54 @@
+package com.hanyahunya.auth.infra.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+public class UserContextFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String userId = request.getHeader("X-USER-ID");
+        String userRoles = request.getHeader("X-USER-ROLES");
+
+        if (userId != null && !userId.isEmpty()) {
+            try {
+                List<GrantedAuthority> authorities = AuthorityUtils.commaSeparatedStringToAuthorityList(userRoles);
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        authorities
+                );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("UserContextFilter: ユーザー '{}' の SecurityContextHolder が設定されました", userId);
+
+            } catch (Exception e) {
+                log.error("UserContextFilter: セキュリティコンテキストにユーザー認証を設定できませんでした", e);
+                SecurityContextHolder.clearContext();
+            }
+        } else {
+            log.debug("UserContextFilter: ヘッダーにユーザーIDが存在しません。パス: {}", request.getRequestURI());
+        }
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            // リクエスト処理が完了したら必ず SecurityContext をクリアします。
+            SecurityContextHolder.clearContext();
+        }
+    }
+}

--- a/src/main/java/com/hanyahunya/kafkaDto/SendSystemMailEvent.java
+++ b/src/main/java/com/hanyahunya/kafkaDto/SendSystemMailEvent.java
@@ -1,0 +1,20 @@
+package com.hanyahunya.kafkaDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendSystemMailEvent {
+    String to;
+    String subject;
+    String templateName;
+    Map<String, String> variables;
+    String locale;
+}


### PR DESCRIPTION
- 正常系ユーザー（ACTIVE状態）のログインロジックを実装しました。

- メールサーバーへのリクエスト方式を、従来のgRPCからKafkaメッセージングに変更し、非同期処理に移行しました。

- 全レイヤーで共有されていた`SignupDto`を、関心事の分離のためWeb層の`Dto`とApplication層の`Command`に分離しました。
  - （補足）Commandオブジェクトはまだ複数箇所で共有されており、今後リファクタリング予定です。

- `locale`フィールドの入力値として "ja-JP", "ko-KR", "en-US" のみを許容するカスタムバリデーションアノテーション `@SupportedLocale` を追加しました。