### PR TITLE
feat: OIDCハイブリッドフローを導入し、ソーシャルログイン処理を最適化

### DIFF
--- a/src/main/java/com/hanyahunya/auth/adapter/in/web/AuthController.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/web/AuthController.java
@@ -62,10 +62,17 @@ public class AuthController {
         return ResponseEntity.ok().headers(headers).build();
     }
 
-    @PostMapping("/login/{provider}")
+    // todo 나중에 Google, Github, Kakao, Naver 등 각 소셜에 맞는 혹은 동일한 종류로 나눠서 처리 필요 (nonce, id_token등 형식이 다르게에?)
+    @PostMapping("/login/{provider}") // 10.07 일단 nonce 있는거로 (Google)
     public ResponseEntity<Void> socialLogin(@PathVariable("provider") String provider, @RequestBody @Valid SocialLoginDto requestDto) {
 
-        SocialLoginCommand command = new SocialLoginCommand(Provider.valueOf(provider.toUpperCase()), requestDto.getValidateCode(), requestDto.getLocale());
+        SocialLoginCommand command = new SocialLoginCommand(
+                Provider.valueOf(provider.toUpperCase()),
+                requestDto.getValidateCode(),
+                requestDto.getIdToken(),
+                requestDto.getNonce(),
+                requestDto.getLocale()
+        );
 
         Tokens tokens = authService.socialLogin(command);
 

--- a/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/SocialLoginDto.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/in/web/dto/SocialLoginDto.java
@@ -11,6 +11,10 @@ public class SocialLoginDto {
     @JsonProperty("code")
     private String validateCode;
     @NotBlank
+    private String idToken;
+    @NotBlank
+    private String nonce;
+    @NotBlank
     @SupportedLocale
     private String locale;
 }

--- a/src/main/java/com/hanyahunya/auth/adapter/out/grpc/GoogleLoginAdapter.java
+++ b/src/main/java/com/hanyahunya/auth/adapter/out/grpc/GoogleLoginAdapter.java
@@ -2,38 +2,26 @@ package com.hanyahunya.auth.adapter.out.grpc;
 
 import com.hanyahunya.auth.application.port.out.SocialLoginPort;
 import com.hanyahunya.auth.domain.model.Provider;
-import google_login.GoogleLoginServiceGrpc;
-import google_login.LoginRequest;
-import google_login.LoginResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import social_login.LoginRequest;
+import social_login.SocialLoginServiceGrpc;
 
 @Service
 @RequiredArgsConstructor
 public class GoogleLoginAdapter implements SocialLoginPort {
 
-    private final GoogleLoginServiceGrpc.GoogleLoginServiceBlockingStub googleLoginStub;
+    private final SocialLoginServiceGrpc.SocialLoginServiceBlockingStub socialLoginStub;
 
     @Override
-    public String processLogin(String validateCode) {
+    public void processLogin(String validateCode) {
         LoginRequest request = LoginRequest.newBuilder()
+                .setProvider(Provider.GOOGLE.name())
                 .setAuthorizationCode(validateCode)
                 .build();
         // todo 고유값 가져와서 이미 있는 쌍인지 확인후 있으면 해당 user_id로 토큰발급후 로그인 처리 없으면 회원가입 처리후 로그인 처리
         try {
-            // 2. integration-service에 gRPC 요청을 보내고 응답을 받음 (동기 방식)
-            LoginResponse response = googleLoginStub.googleLogin(request);
-
-            String userSub = response.getSub();
-
-            // 3. 받은 sub 값으로 우리 서비스의 DB에서 유저 조회 또는 회원가입 처리
-            // ... (auth-service의 핵심 로직) ...
-
-            // 4. 우리 서비스의 JWT 토큰 발급 후 반환
-            // return jwtTokenProvider.createToken(userSub);
-
-            return userSub; // 임시로 sub 반환
+            socialLoginStub.socialLogin(request);
 
         } catch (Exception e) {
             // gRPC 통신 오류 또는 integration-service에서 발생한 에러 처리

--- a/src/main/java/com/hanyahunya/auth/application/command/SocialLoginCommand.java
+++ b/src/main/java/com/hanyahunya/auth/application/command/SocialLoginCommand.java
@@ -2,5 +2,5 @@ package com.hanyahunya.auth.application.command;
 
 import com.hanyahunya.auth.domain.model.Provider;
 
-public record SocialLoginCommand(Provider provider, String validateCode, String locale) {
+public record SocialLoginCommand(Provider provider, String validateCode, String idToken, String nonce, String locale) {
 }

--- a/src/main/java/com/hanyahunya/auth/application/port/out/AccessLockPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/AccessLockPort.java
@@ -5,5 +5,5 @@ import java.util.UUID;
 public interface AccessLockPort {
     void lock(UUID userId, long compromisedAt);
 
-    void unlock(UUID userId);
+//    void unlock(UUID userId);
 }

--- a/src/main/java/com/hanyahunya/auth/application/port/out/SocialLoginPort.java
+++ b/src/main/java/com/hanyahunya/auth/application/port/out/SocialLoginPort.java
@@ -3,7 +3,7 @@ package com.hanyahunya.auth.application.port.out;
 import com.hanyahunya.auth.domain.model.Provider;
 
 public interface SocialLoginPort {
-    String processLogin(String validateCode);
+    void processLogin(String validateCode);
 
     Provider getProvider();
 }

--- a/src/main/java/com/hanyahunya/auth/application/security/GoogleIdTokenValidator.java
+++ b/src/main/java/com/hanyahunya/auth/application/security/GoogleIdTokenValidator.java
@@ -1,0 +1,131 @@
+package com.hanyahunya.auth.application.security;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanyahunya.auth.domain.exception.InvalidTokenException;
+import com.hanyahunya.auth.domain.model.Provider;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// todo 추후 올바른 예외 클래스로 변경.
+@Slf4j
+@Component
+public class GoogleIdTokenValidator implements IdTokenValidator {
+
+    @Value("${oauth2.google.client-id}")
+    private String googleClientId;
+
+    @Value("${oauth2.google.issuer}")
+    private String googleIssuer;
+
+    private static final String GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Map<String, Key> publicKeyCache = new ConcurrentHashMap<>();
+
+    private final Locator<Key> keyLocator = new Locator<Key>() {
+        @Override
+        public Key locate(Header header) {
+            String keyId = (String) header.get("kid");
+            if (keyId == null) {
+                throw new InvalidTokenException("ID 토큰 헤더에 'kid'가 없습니다.");
+            }
+            if (publicKeyCache.containsKey(keyId)) {
+                return publicKeyCache.get(keyId);
+            }
+            return refreshPublicKeysAndGet(keyId);
+        }
+    };
+
+    @Override
+    public String validateAndGetSub(String idToken, String nonce) {
+        try {
+            Jws<Claims> jwsClaims = Jwts.parser()
+                    .keyLocator(keyLocator)
+                    .build()
+                    .parseSignedClaims(idToken);
+
+            Claims claims = jwsClaims.getPayload();
+            validateClaims(claims, nonce);
+            return claims.getSubject();
+
+        } catch (ExpiredJwtException e) {
+            throw new InvalidTokenException("ID 토큰이 만료되었습니다.");
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
+            throw new InvalidTokenException("유효하지 않은 형식의 ID 토큰입니다.");
+        } catch (InvalidTokenException e) {
+            // validateClaims 또는 keyLocator에서 발생한 InvalidTokenException을 그대로 다시 던짐
+            throw e;
+        } catch (Exception e) {
+            log.error("ID Token validation failed: {}", e.getMessage());
+            throw new InvalidTokenException("ID 토큰 검증에 실패했습니다.");
+        }
+    }
+
+    private Key refreshPublicKeysAndGet(String keyId) {
+        try {
+            URL jwksUrl = URI.create(GOOGLE_JWKS_URL).toURL();
+            Map<String, List<Map<String, String>>> keys = objectMapper.readValue(jwksUrl, new TypeReference<>() {});
+            List<Map<String, String>> keyList = keys.get("keys");
+
+            publicKeyCache.clear();
+
+            for (Map<String, String> keyMap : keyList) {
+                BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(keyMap.get("n")));
+                BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(keyMap.get("e")));
+                RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+                KeyFactory factory = KeyFactory.getInstance("RSA");
+                Key publicKey = factory.generatePublic(spec);
+                publicKeyCache.put(keyMap.get("kid"), publicKey);
+            }
+
+            if (publicKeyCache.containsKey(keyId)) {
+                return publicKeyCache.get(keyId);
+            } else {
+                throw new InvalidTokenException("ID 토큰에 해당하는 공개키를 찾을 수 없습니다. (kid=" + keyId + ")");
+            }
+
+        } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+            log.error("Failed to refresh Google public keys", e);
+            throw new RuntimeException("Google 공개키를 가져오거나 생성하는 데 실패했습니다.", e);
+        }
+    }
+
+    private void validateClaims(Claims claims, String expectedNonce) {
+        if (!googleIssuer.equals(claims.getIssuer())) {
+            throw new InvalidTokenException("ID 토큰의 발급자(issuer)가 일치하지 않습니다.");
+        }
+        if (!googleClientId.equals(claims.getAudience().iterator().next())) {
+            throw new InvalidTokenException("ID 토큰의 대상(audience)이 일치하지 않습니다.");
+        }
+        if (claims.getExpiration().before(new Date())) {
+            throw new InvalidTokenException("ID 토큰이 만료되었습니다.");
+        }
+        String tokenNonce = claims.get("nonce", String.class);
+        if (tokenNonce == null || !tokenNonce.equals(expectedNonce)) {
+            throw new InvalidTokenException("ID 토큰의 Nonce 값이 일치하지 않습니다.");
+        }
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.GOOGLE;
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/application/security/IdTokenValidator.java
+++ b/src/main/java/com/hanyahunya/auth/application/security/IdTokenValidator.java
@@ -1,0 +1,8 @@
+package com.hanyahunya.auth.application.security;
+
+import com.hanyahunya.auth.domain.model.Provider;
+
+public interface IdTokenValidator {
+    String validateAndGetSub(String idToken, String nonce);
+    Provider getProvider();
+}

--- a/src/main/java/com/hanyahunya/auth/application/security/IdTokenValidatorFactory.java
+++ b/src/main/java/com/hanyahunya/auth/application/security/IdTokenValidatorFactory.java
@@ -1,0 +1,29 @@
+package com.hanyahunya.auth.application.security;
+
+import com.hanyahunya.auth.domain.model.Provider;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class IdTokenValidatorFactory {
+    private final Map<Provider, IdTokenValidator> idTokenValidator;
+
+    public IdTokenValidatorFactory(List<IdTokenValidator> validators) {
+        this.idTokenValidator = validators.stream()
+                .collect(Collectors.toMap(
+                        IdTokenValidator::getProvider,
+                        validator -> validator
+                ));
+    }
+
+    public IdTokenValidator getIdTokenValidator(Provider provider) {
+        IdTokenValidator validator = idTokenValidator.get(provider);
+        if (validator == null) {
+            throw new IllegalArgumentException("unsupported provider type: " + provider);
+        }
+        return validator;
+    }
+}

--- a/src/main/java/com/hanyahunya/auth/domain/exception/InvalidTokenException.java
+++ b/src/main/java/com/hanyahunya/auth/domain/exception/InvalidTokenException.java
@@ -4,4 +4,7 @@ public class InvalidTokenException extends RuntimeException {
   public InvalidTokenException() {
     super("認証トークンが無効か、または有効期限が切れています。");
   }
+  public InvalidTokenException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/hanyahunya/auth/infra/config/GrpcClientConfig.java
+++ b/src/main/java/com/hanyahunya/auth/infra/config/GrpcClientConfig.java
@@ -1,12 +1,11 @@
 package com.hanyahunya.auth.infra.config;
 
 import email_service.EmailServiceGrpc;
-import google_login.GoogleLoginServiceGrpc;
 import io.grpc.ManagedChannel;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.grpc.client.GrpcChannelFactory;
+import social_login.SocialLoginServiceGrpc;
 
 @Configuration
 public class GrpcClientConfig {
@@ -24,9 +23,8 @@ public class GrpcClientConfig {
     }
 
     @Bean
-//    @Qualifier("googleLoginStub")
-    GoogleLoginServiceGrpc.GoogleLoginServiceBlockingStub googleLoginServiceStub(GrpcChannelFactory channelFactory) {
+    SocialLoginServiceGrpc.SocialLoginServiceBlockingStub socialLoginServiceStub(GrpcChannelFactory channelFactory) {
         ManagedChannel channel = channelFactory.createChannel("integration-service");
-        return GoogleLoginServiceGrpc.newBlockingStub(channel);
+        return SocialLoginServiceGrpc.newBlockingStub(channel);
     }
 }

--- a/src/main/java/com/hanyahunya/kafkaDto/ProcessSocialTokenEvent.java
+++ b/src/main/java/com/hanyahunya/kafkaDto/ProcessSocialTokenEvent.java
@@ -1,0 +1,16 @@
+package com.hanyahunya.kafkaDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProcessSocialTokenEvent {
+    private String provider;
+    private String userSub;
+    private String authorizationCode;
+}

--- a/src/main/java/com/hanyahunya/kafkaDto/SendSystemMailEvent.java
+++ b/src/main/java/com/hanyahunya/kafkaDto/SendSystemMailEvent.java
@@ -12,9 +12,9 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SendSystemMailEvent {
-    String to;
-    String subject;
-    String templateName;
-    Map<String, String> variables;
-    String locale;
+    private String to;
+    private String subject;
+    private String templateName;
+    private Map<String, String> variables;
+    private String locale;
 }

--- a/src/main/proto/google_login.proto
+++ b/src/main/proto/google_login.proto
@@ -1,22 +1,23 @@
 syntax = "proto3";
-// 생성될 자바 클래스들의 패키지 경로를 지정
-package google_login;
+
+import "google/protobuf/empty.proto";
+
+// 생성될 자바 클래스들의 패키지 경로를 지정합니다. (패키지명 변경)
+package social_login;
 
 option java_multiple_files = true;
 
-// Google 로그인 처리를 위한 gRPC 서비스 정의
-service GoogleLoginService {
-  rpc GoogleLogin (LoginRequest) returns (LoginResponse);
+// 소셜 로그인 처리를 위한 gRPC 서비스 정의 (이름 변경)
+service SocialLoginService {
+  // 인증 코드를 사용하여 소셜 로그인을 처리하고 사용자의 고유 ID를 반환합니다.
+  rpc SocialLogin (LoginRequest) returns (google.protobuf.Empty);
 }
 
-// 로그인 처리 요청 메시지
+// 로그인 처리 요청 메시지 (provider 필드 추가)
 message LoginRequest {
-  // 프론트엔드에서 Google로부터 받은 임시 인증 코드 (예: "4/0A...")
-  string authorization_code = 1;
-}
+  // 어떤 소셜 제공업체인지 구분하기 위한 문자열 (예: "GOOGLE", "KAKAO")
+  string provider = 1;
 
-// 로그인 처리 응답 메시지
-message LoginResponse {
-  // Google 계정의 고유 식별자 (Subject)
-  string sub = 1;
+  // 프론트엔드에서 소셜 제공업체로부터 받은 임시 인증 코드
+  string authorization_code = 2;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,11 @@ spring:
           address: static://localhost:9091
           negotiation-type: plaintext
 
+oauth2:
+  google:
+    client-id: ${TASKE_GOOGLE_CLIENT_ID}
+    issuer: https://accounts.google.com
+
 app:
   frontend:
     url: https://hanyahunya.com/taske


### PR DESCRIPTION
GoogleログインをはじめとするOIDCベースのソーシャルログインフローを大幅に改善します。
従来は`integration-service`への同期gRPCコールに依存していましたが、`auth-service`が直接`id_token`を検証する方式に変更し、パフォーマンスとアーキテクチャを最適化しました。

主な変更点:

- **OIDC `id_token`の直接検証機能を追加 (`auth-service`):**
  - フロントエンドから受け取った`id_token`の署名、発行者(`iss`)、対象者(`aud`)、有効期限(`exp`)、そして`nonce`を`auth-service`内で直接検証する`IdTokenValidator`を実装しました。
  - Googleの公開鍵(JWKS)を動的に取得・キャッシュし、`jjwt`ライブラリの`keyLocator`を用いて安全に署名を検証します。
  - これにより、`auth-service`がユーザー認証の責任を完全に持つようになり、セキュリティが向上しました。

- **既存ユーザーのログインフローを高速化:**
  - 既存のソーシャルアカウントを持つユーザーは、`id_token`の検証が成功した時点で即座にログイン処理が完了し、`integration-service`との通信が不要になりました。
  - これにより、ログイン時のレスポンスタイムが大幅に短縮され、ユーザーエクスペリエンスが向上します。

- **新規ユーザー登録時の通信方式を変更 (gRPC -> 非同期):**
  - 新規ユーザーの場合にのみ、`authorization_code`を`integration-service`に渡してアクセストークンとリフレッシュトークンの保存を依頼します。
  - この通信は、従来の sub を同期的に返す gRPC 方式から離れ、Empty レスポンスを用いた非同期的な「Fire-and-Forget」呼び出しに変更されました。（将来的には Kafka への移行を想定した設計です）

- **APIおよびDTOの仕様変更:**
  - `/login/{provider}`エンドポイントのDTO(`SocialLoginDto`)に`idToken`と`nonce`フィールドを追加しました。
  - 内部コマンド(`SocialLoginCommand`)も新しいフローに対応するよう更新しました。

- **gRPCプロトコルの汎用化と変更:**
  - `google_login.proto`を`social_login.proto`に名称変更し、リクエストに`provider`フィールドを追加して汎用性を確保しました。
  - レスポンスメッセージを`LoginResponse`から`google.protobuf.Empty`に変更し、非同期的な呼び出しであることを明確にしました。